### PR TITLE
Disable tslint in typechain-runtime.ts

### DIFF
--- a/runtime/typechain-runtime.ts
+++ b/runtime/typechain-runtime.ts
@@ -1,3 +1,4 @@
+/* tslint:disable */
 import { BigNumber } from "bignumber.js";
 
 export interface ITxParams {


### PR DESCRIPTION
- Typechain-runtime gets copied to the project
- If the linting rules don't match, you'd have to go into this file and add a tslint disable tag every time it's generated.