### PR TITLE
Fix for https://github.com/Neufund/TypeChain/issues/39

### DIFF
--- a/lib/generateSource.ts
+++ b/lib/generateSource.ts
@@ -1,6 +1,6 @@
 import { RawAbiDefinition, parse, Contract, AbiParameter } from "./abiParser";
 import { getVersion } from "./utils";
-import { EvmType } from "./typeParser";
+import { EvmType, ArrayType } from "./typeParser";
 
 export interface IContext {
   fileName: string;
@@ -85,7 +85,9 @@ function codeGenForParams(param: AbiParameter, index: number): string {
 }
 
 function codeGenForArgs(param: AbiParameter, index: number): string {
-  return `(${param.name || `arg${index}`}).toString()`;
+  const isArray = param.type instanceof ArrayType;
+  const paramName = param.name || `arg${index}`;
+  return isArray ? `${paramName}.map(val => val.toString())` : `${paramName}.toString()`;
 }
 
 function codeGenForOutputTypeList(output: Array<EvmType>): string {

--- a/test/integration/DumbContract.spec.ts
+++ b/test/integration/DumbContract.spec.ts
@@ -69,4 +69,17 @@ describe("DumbContract", () => {
       `Contract at ${wrongAddress} doesn't exist!`,
     );
   });
+
+  it("should allow calling a function which takes an array param", async () => {
+    const dumbContract = await DumbContract.createAndValidate(web3, contractAddress);
+
+    expect((await dumbContract.arrayParamLength).toString()).to.be.eq("0");
+
+    await dumbContract
+      .callWithArrayTx([new BigNumber(41), new BigNumber(42), new BigNumber(43)])
+      .send({ from: accounts[0], gas: GAS_LIMIT_STANDARD});
+  
+    // Make sure the value has been set as expected
+    expect((await dumbContract.arrayParamLength).toString()).to.be.eq("3");
+  });
 });

--- a/test/integration/contracts/DumbContract.sol
+++ b/test/integration/contracts/DumbContract.sol
@@ -5,6 +5,7 @@ contract DumbContract {
   bool constant public SOME_VALUE = true;
   uint[] public counterArray;
   address public someAddress;
+  uint public arrayParamLength;
 
   function DumbContract() public {
     counter = 0;
@@ -38,5 +39,11 @@ contract DumbContract {
   // repro for https://github.com/Neufund/TypeChain/issues/29
   function twoUnnamedArgs(uint8, uint8, uint ret) payable public returns (uint) {
     return ret;
+  }
+
+  // repro for https://github.com/Neufund/TypeChain/issues/39
+  function callWithArray(uint256[] arrayParam) public returns (uint) {
+    arrayParamLength = arrayParam.length;
+    return arrayParam.length;
   }
 }


### PR DESCRIPTION
The fix here is simply to check what type the input argument is and special case arrays. Instead of just calling to string on the array, we map the values of the array to their string representation. I added an integration test for the case as well