### PR TITLE
Fix for https://github.com/Neufund/TypeChain/issues/41 - Handle bytes as an input type

### DIFF
--- a/lib/generateSource.ts
+++ b/lib/generateSource.ts
@@ -1,6 +1,6 @@
 import { RawAbiDefinition, parse, Contract, AbiParameter } from "./abiParser";
 import { getVersion } from "./utils";
-import { EvmType, ArrayType } from "./typeParser";
+import { EvmType } from "./typeParser";
 
 export interface IContext {
   fileName: string;
@@ -85,9 +85,8 @@ function codeGenForParams(param: AbiParameter, index: number): string {
 }
 
 function codeGenForArgs(param: AbiParameter, index: number): string {
-  const isArray = param.type instanceof ArrayType;
   const paramName = param.name || `arg${index}`;
-  return isArray ? `${paramName}.map(val => val.toString())` : `${paramName}.toString()`;
+  return param.type.generateCodeForInputConversion(paramName);
 }
 
 function codeGenForOutputTypeList(output: Array<EvmType>): string {

--- a/lib/typeParser.ts
+++ b/lib/typeParser.ts
@@ -3,6 +3,10 @@ export abstract class EvmType {
     return this.generateCodeForOutput();
   }
   abstract generateCodeForOutput(): string;
+
+  generateCodeForInputConversion(paramName: string): string {
+    return `${paramName}.toString()`;
+  }
 }
 
 export class BooleanType extends EvmType {
@@ -49,6 +53,9 @@ export class StringType extends EvmType {
   generateCodeForOutput(): string {
     return "string";
   }
+  generateCodeForInputConversion(paramName: string): string {
+    return paramName;
+  }
 }
 
 export class BytesType extends EvmType {
@@ -78,6 +85,18 @@ export class ArrayType extends EvmType {
 
   generateCodeForOutput(): string {
     return this.itemType.generateCodeForOutput() + "[]";
+  }
+
+  generateCodeForInput(): string {
+    return this.itemType instanceof BytesType ? "string" : this.generateCodeForOutput();
+  }
+
+  generateCodeForInputConversion(paramName: string): string {
+    if (this.itemType instanceof BytesType) {
+      return paramName;
+    } else {
+      return `${paramName}.map(val => ${this.itemType.generateCodeForInputConversion("val")})`;
+    }
   }
 }
 

--- a/test/integration/DumbContract.spec.ts
+++ b/test/integration/DumbContract.spec.ts
@@ -82,4 +82,16 @@ describe("DumbContract", () => {
     // Make sure the value has been set as expected
     expect((await dumbContract.arrayParamLength).toString()).to.be.eq("3");
   });
+
+  it("should allow calling a function which takes a bytes array", async () => {
+    const dumbContract = await DumbContract.createAndValidate(web3, contractAddress);
+
+    const bytesString = "0xabcd123456"; // 5 bytes long (each pair of chars is a byte)
+    const bytesLength = await dumbContract.callWithBytes(bytesString);
+    expect(bytesLength.toNumber()).to.be.eq(5);
+
+    const charString = "hello_world!"; // 12 bytes long (each char is a byte)
+    const charStringLength = await dumbContract.callWithBytes(charString);
+    expect(charStringLength.toNumber()).to.be.eq(12);
+  });
 });

--- a/test/integration/contracts/DumbContract.sol
+++ b/test/integration/contracts/DumbContract.sol
@@ -46,4 +46,8 @@ contract DumbContract {
     arrayParamLength = arrayParam.length;
     return arrayParam.length;
   }
+
+  function callWithBytes(bytes byteArray) public view returns (uint) {
+    return byteArray.length;
+  }
 }


### PR DESCRIPTION
This change introduces a new `generateCodeForInputConversion` on the EvmType class which is used for converting from the input type to the type which web3 is expecting.