### PR TITLE
Allow "tuple" type in ABIs

### DIFF
--- a/lib/abiParser.ts
+++ b/lib/abiParser.ts
@@ -41,6 +41,7 @@ export interface Contract {
 export interface RawAbiParameter {
   name: string;
   type: string;
+  components?: RawAbiParameter[];
 }
 
 export interface RawAbiDefinition {
@@ -74,6 +75,7 @@ export interface RawEventArgAbiDefinition {
   indexed: boolean;
   name: string;
   type: string;
+  components?: RawAbiParameter[];
 }
 
 export function parse(abi: Array<RawAbiDefinition>): Contract {
@@ -150,7 +152,7 @@ function parseOutputs(outputs: Array<RawAbiParameter>): EvmType[] {
   if (outputs.length === 0) {
     return [new VoidType()];
   } else {
-    return outputs.map(param => parseEvmType(param.type));
+    return outputs.map(param => parseEvmType(param.type, param.components));
   }
 }
 
@@ -158,7 +160,7 @@ function parseConstant(abiPiece: RawAbiDefinition): ConstantDeclaration {
   debug(`Parsing constant "${abiPiece.name}"`);
   return {
     name: abiPiece.name,
-    output: parseEvmType(abiPiece.outputs[0].type),
+    output: parseEvmType(abiPiece.outputs[0].type, abiPiece.outputs[0].components),
   };
 }
 
@@ -175,7 +177,7 @@ function parseRawEventArg(eventArg: RawEventArgAbiDefinition): EventArgDeclarati
   return {
     name: eventArg.name,
     isIndexed: eventArg.indexed,
-    type: parseEvmType(eventArg.type),
+    type: parseEvmType(eventArg.type, eventArg.components),
   };
 }
 
@@ -201,7 +203,7 @@ function parseFunctionDeclaration(abiPiece: RawAbiDefinition): FunctionDeclarati
 function parseRawAbiParameter(rawAbiParameter: RawAbiParameter): AbiParameter {
   return {
     name: rawAbiParameter.name,
-    type: parseEvmType(rawAbiParameter.type),
+    type: parseEvmType(rawAbiParameter.type, rawAbiParameter.components),
   };
 }
 

--- a/test/unit/parseEvmType.spec.ts
+++ b/test/unit/parseEvmType.spec.ts
@@ -6,6 +6,7 @@ import {
   BooleanType,
   ArrayType,
   BytesType,
+  TupleType,
 } from "../../lib/typeParser";
 
 describe("parseEvmType function", () => {
@@ -64,5 +65,25 @@ describe("parseEvmType function", () => {
     expect(
       (((parsedType as ArrayType).itemType as ArrayType).itemType as UnsignedIntegerType).bits,
     ).to.be.eq(16);
+  });
+
+  it("should parse tuples", () => {
+    const parsedType = parseEvmType("tuple", [
+      {
+        name: "arg1",
+        type: "uint8",
+      },
+      {
+        name: "arg2",
+        type: "bool",
+      },
+    ]);
+
+    expect(parsedType).to.be.instanceOf(TupleType);
+    expect((parsedType as TupleType).itemTypes).to.be.instanceOf(Array);
+    expect((parsedType as TupleType).itemTypes.length).to.be.eq(2);
+    expect((parsedType as TupleType).itemTypes[0]).to.be.instanceOf(UnsignedIntegerType);
+    expect((parsedType as TupleType).itemTypes[1]).to.be.instanceOf(BooleanType);
+    expect(parsedType.generateCodeForOutput()).to.be.eq("[BigNumber, boolean]");
   });
 });


### PR DESCRIPTION
Thanks for this great library! I have an ABI that contains a output with type `tuple`, which (at least with truffle) means the type will include a `components` key with a list of sub-types.

This allows TypeChain to build typescript tuples out of those ABI tuples.