### PR TITLE
added support for bytes32 as argument to solidity fx

### DIFF
--- a/lib/typeParser.ts
+++ b/lib/typeParser.ts
@@ -57,7 +57,7 @@ export class BytesType extends EvmType {
   }
 
   generateCodeForOutput(): string {
-    return "BigNumber";
+    return "string";
   }
 }
 

--- a/test/integration/DumbContract.spec.ts
+++ b/test/integration/DumbContract.spec.ts
@@ -175,4 +175,13 @@ describe("DumbContract", () => {
     expect(singleEvent.length).to.eq(1);
     expect(singleEvent[0].args.from).to.eq(accounts[1]);
   }).timeout(LONG_TIMEOUT);
+
+  it("should allow for strings to be used for byte arrays", async () => {
+    const dumbContract = await DumbContract.createAndValidate(web3, contractAddress);
+    const byteString = "0xabcd123456000000000000000000000000000000000000000000000000000000";
+    await dumbContract
+      .callWithBytesTx(byteString)
+      .send({ from: accounts[1], gas: GAS_LIMIT_STANDARD });
+    expect(await dumbContract.byteArray).to.eq(byteString);
+  });
 });

--- a/test/integration/contracts/DumbContract.sol
+++ b/test/integration/contracts/DumbContract.sol
@@ -6,6 +6,7 @@ contract DumbContract {
   uint[] public counterArray;
   address public someAddress;
   uint public arrayParamLength;
+  bytes32 public byteArray;
 
   function DumbContract() public {
     counter = 0;
@@ -46,6 +47,11 @@ contract DumbContract {
   function callWithArray(uint256[] arrayParam) public returns (uint) {
     arrayParamLength = arrayParam.length;
     return arrayParam.length;
+  }
+
+  function callWithBytes(bytes32 byteParam) public returns (bool) {
+    byteArray = byteParam; // to silence warnings
+    return true;
   }
 
   event Deposit(


### PR DESCRIPTION
Hello Typechain team!

This pr fixes issues with #41 and also https://github.com/MARKETProtocol/types/issues/18
cc @eswarasai

I believe this fixes issues where a type definition is generated for a solidity function that accepts a `bytes32`  type argument.   We would love to get this included in a release as soon as possible, so if there is anything else needed here please let me know and I am happy to contribute. 

We just started using your package in our project, thank you for all you guys are doing!